### PR TITLE
Make loginSilent public

### DIFF
--- a/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
@@ -27,4 +27,11 @@ public interface IAuthenticationAdapter extends IAuthenticationProvider  {
      * @param callback The callback when the login is complete or an error occurs
      */
     void login(final Activity activity, final ICallback<Void> callback);
+
+    /**
+     * Login a user with no ui
+     *
+     * @param callback The callback when the login is complete or an error occurs
+     */
+    void loginSilent(final ICallback<Void> callback);
 }

--- a/lib/src/main/java/com/microsoft/graph/authentication/MSAAuthAndroidAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/MSAAuthAndroidAdapter.java
@@ -214,6 +214,7 @@ public abstract class MSAAuthAndroidAdapter implements IAuthenticationAdapter {
      *
      * @param callback The callback when the login is complete or an error occurs
      */
+    @Override
     public void loginSilent(final ICallback<Void> callback) {
         mLogger.logDebug("Login silent started");
 

--- a/lib/src/main/java/com/microsoft/graph/authentication/MSAAuthAndroidAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/MSAAuthAndroidAdapter.java
@@ -214,7 +214,7 @@ public abstract class MSAAuthAndroidAdapter implements IAuthenticationAdapter {
      *
      * @param callback The callback when the login is complete or an error occurs
      */
-    private void loginSilent(final ICallback<Void> callback) {
+    public void loginSilent(final ICallback<Void> callback) {
         mLogger.logDebug("Login silent started");
 
         if (callback == null) {


### PR DESCRIPTION
I couldn't see any reason this should be private. It's nice to try to log in silently without the context of an application (such as in a background thread) before requiring a log in screen.

This addresses the proposed fix for issue #4.