### PR TITLE
getAccessToken on IAuthenticationAdapter

### DIFF
--- a/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
@@ -39,6 +39,7 @@ public interface IAuthenticationAdapter extends IAuthenticationProvider  {
     /**
      * Gets the access token for the session of a logged in user
      *
+     * @return the access token
      * @throws ClientException if the session isn't valid
      */
     String getAccessToken() throws ClientException;

--- a/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
@@ -7,6 +7,7 @@ package com.microsoft.graph.authentication;
 import android.app.Activity;
 
 import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.core.ClientException;
 
 /**
  * An authentication adapter for signing requests, logging in, and logging out.
@@ -34,4 +35,11 @@ public interface IAuthenticationAdapter extends IAuthenticationProvider  {
      * @param callback The callback when the login is complete or an error occurs
      */
     void loginSilent(final ICallback<Void> callback);
+
+    /**
+     * Gets the access token for the session of a logged in user
+     *
+     * @throws ClientException if the session isn't valid
+     */
+    String getAccessToken() throws ClientException;
 }

--- a/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/IAuthenticationAdapter.java
@@ -40,7 +40,6 @@ public interface IAuthenticationAdapter extends IAuthenticationProvider  {
      * Gets the access token for the session of a logged in user
      *
      * @return the access token
-     * @throws ClientException if the session isn't valid
      */
     String getAccessToken() throws ClientException;
 }

--- a/lib/src/main/java/com/microsoft/graph/authentication/MSAAuthAndroidAdapter.java
+++ b/lib/src/main/java/com/microsoft/graph/authentication/MSAAuthAndroidAdapter.java
@@ -101,20 +101,33 @@ public abstract class MSAAuthAndroidAdapter implements IAuthenticationAdapter {
             }
         }
 
+        try {
+            final String accessToken = getAccessToken();
+            request.addHeader(AUTHORIZATION_HEADER_NAME, OAUTH_BEARER_PREFIX + accessToken);
+        } catch (ClientException e) {
+            final String message = "Unable to authenticate request, No active account found";
+            final ClientException exception = new ClientException(message,
+                e,
+                GraphErrorCodes.AuthenticationFailure);
+            mLogger.logError(message, exception);
+            throw exception;
+        }
+    }
+
+    @Override
+    public String getAccessToken() throws ClientException {
         if (hasValidSession()) {
             mLogger.logDebug("Found account information");
             if (mLiveAuthClient.getSession().isExpired()) {
                 mLogger.logDebug("Account access token is expired, refreshing");
                 loginSilentBlocking();
             }
-
-            final String accessToken = mLiveAuthClient.getSession().getAccessToken();
-            request.addHeader(AUTHORIZATION_HEADER_NAME, OAUTH_BEARER_PREFIX + accessToken);
+            return mLiveAuthClient.getSession().getAccessToken();
         } else {
-            final String message = "Unable to authenticate request, No active account found";
+            final String message = "Unable to get access token, No active account found";
             final ClientException exception = new ClientException(message,
-                                                                  null,
-                                                                  GraphErrorCodes.AuthenticationFailure);
+                null,
+                GraphErrorCodes.AuthenticationFailure);
             mLogger.logError(message, exception);
             throw exception;
         }


### PR DESCRIPTION
users of the SDK may want to use the access token outside of the currently given implementation (e.g. to pass on to be used through cross-platform code implementations or via a server proxy), so I've made the token publicly accessible 